### PR TITLE
Create PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,29 @@
+pkgname=game-engine-finder-git
+pkgver=r18.f788f96
+pkgrel=1
+pkgdesc="Python script for easily figuring out the engine used for a game"
+arch=('any')
+url="https://github.com/vetleledaal/game-engine-finder"
+license=('unknown')
+groups=()
+depends=('python')
+makedepends=('git')
+provides=("${pkgname%-git}")
+conflicts=("${pkgname%-git}")
+replaces=()
+backup=()
+options=()
+install=
+source=('game-engine-finder::git+https://github.com/vetleledaal/game-engine-finder.git')
+noextract=()
+md5sums=('SKIP')
+
+pkgver() {
+        cd "$srcdir/${pkgname%-git}"
+        printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+package() {
+        cd "$srcdir/${pkgname%-git}"
+        install -Dm755 find-engine.py ${pkgdir}/usr/bin/find-engine
+}


### PR DESCRIPTION
This it the PKGBUILD I use on my system, it should work with all Linux distro that uses pacman (Arch Linux, Manjaro, etc.)

It install the script in `/usr/bin/find-engine` so just `find-engine path/to/game/exe` can be used, but it requires #10 to work. It currently doesn't change username and there's no maintainer filled to be used on [AUR](https://aur.archlinux.org/). I don't know if there's a license, so it's currently filled as *unknown*.