### PR TITLE
Refactor Unity `globalgamemanagers` detection

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=game-engine-finder-git
-pkgver=r20.f788f96
+pkgver=r21.f788f96
 pkgrel=1
 pkgdesc="Python script for easily figuring out the engine used for a game"
 arch=('any')

--- a/find_engine.py
+++ b/find_engine.py
@@ -138,9 +138,12 @@ def detect(exe):
                         match = re.search(br'\x00UnityPlayer\/([^\x20]+)', file_data2)
 
             if match and match.group(1).decode('utf-8') == '%s':
-                ggm_files = exe_path.glob('*Data/globalgamemanagers')
-                if ggm_files:
-                    file_data2 = open(ggm_files[0], 'rb').read()
+                # There can be multiple "*_Data" folders if there are multiple
+                # Unity .exe files, so we have to pick the folder corresponding
+                # to this .exe.
+                ggm_file = exe_path / (exe.stem + '_Data') / 'globalgamemanagers'
+                if ggm_file.exists():
+                    file_data2 = open(ggm_file, 'rb').read()
                     match = re.search(br'\x00(\d{1,4}\.\d+\.\d+[a-z]+\d+)\x00', file_data2)
 
             if(not found and match is not None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = game-engine-finder
-version = 0.0.0.20
+version = 0.0.0.21
 description = Python script for easily figuring out the engine used for a game.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
It was inadvertently broken in https://github.com/vetleledaal/game-engine-finder/pull/28

Before that PR, it was still incorrect when multiple games inhabited the same folder.